### PR TITLE
Sign object should have status associated, even if it is not used

### DIFF
--- a/gnupg.py
+++ b/gnupg.py
@@ -665,6 +665,7 @@ class Sign(TextHandler):
         self.type = None
         self.hash_algo = None
         self.fingerprint = None
+        self.status = None
 
     def __nonzero__(self):
         return self.fingerprint is not None


### PR DESCRIPTION
The other status objects have .status associated with them
It is not clear to me if the Sign object adds or modifies .status
However I have encountered another Python project (gajim) that seems to think that it should