### PR TITLE
Set decode_errors to ignore

### DIFF
--- a/gnupg.py
+++ b/gnupg.py
@@ -690,7 +690,7 @@ HEX_DIGITS_RE = re.compile(r'[0-9a-f]+$', re.I)
 
 class GPG(object):
 
-    decode_errors = 'strict'
+    decode_errors = 'ignore'
 
     result_map = {
         'crypt': Crypt,


### PR DESCRIPTION
This change was made in order to solve an issue with a malformed gpg key. Details below:

  File "/usr/lib/python3.6/site-packages/gnupg.py", line 1222, in list_keys
    return self._get_list_output(p, 'list')
  File "/usr/lib/python3.6/site-packages/gnupg.py", line 1174, in _get_list_output
    self.decode_errors).splitlines()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 224037: invalid continuation byte


[arch@arch LSD]$ GNUPGHOME=gnupghome/ gpg -k kundr
pub   dsa1024 2005-04-16 [SC]
      61AB87D6F66CE2FCD2D2E1F56A65DFA844722517
uid           [ unknown] Jan Kundrát (jkt) <jkt@flaska.net>
uid           [ unknown] Jan Kundrát <jkt@kde.org>
uid           [ unknown] Jan Kundr\xe1\x74 <kundratj@fzu.cz>
uid           [ unknown] Jan Kundrát <kundratj@fzu.cz>
uid           [ unknown] Jan Kundrát <jan.kundrat@fzu.cz>
uid           [ unknown] Jan Kundrát (jkt) <jkt@gentoo.org>
sub   elg2048 2005-04-16 [E]