### PR TITLE
scan keys not in a file

### DIFF
--- a/gnupg.py
+++ b/gnupg.py
@@ -1794,7 +1794,7 @@ class GPG(object):
         p = self._open_subprocess(args)
         return self._get_list_output(p, 'list')
 
-    def scan_keys_file(self, filename):
+    def scan_keys(self, filename):
         """
         List details of an ascii armored or binary key file without first importing it to the local keyring.
 
@@ -1821,7 +1821,7 @@ class GPG(object):
         p = self._open_subprocess(args)
         return self._get_list_output(p, 'scan')
 
-    def scan_keys(self, key_data):
+    def scan_keys_mem(self, key_data):
         """
         List details of an ascii armored or binary key without first importing it to the local keyring.
 
@@ -1851,8 +1851,6 @@ class GPG(object):
         logger.debug('scan_keys result: %r', result.__dict__)
         data.close()
         return self._decode_result(result)
-
-        # return result
 
     def search_keys(self, query, keyserver='pgp.mit.edu', extra_args=None):
         """

--- a/test_gnupg.py
+++ b/test_gnupg.py
@@ -707,7 +707,7 @@ class GPGTestCase(unittest.TestCase):
         logger.debug('testing other signature')
         self.assertTrue(('057CCF658C074FDA', 'Winston Smith (A test user) <winston@example.com>', '10x') in sigs)
 
-    def test_scan_keys(self):
+    def test_scan_keys_file(self):
         "Test that external key files can be scanned"
         # Don't use SkipTest for now, as not available for Python < 2.7
         if self.gpg.version < (2, 1):
@@ -718,7 +718,7 @@ class GPGTestCase(unittest.TestCase):
             ])
             for fn in ('test_pubring.gpg', 'test_secring.gpg'):
                 logger.debug('scanning keys in %s', fn)
-                data = self.gpg.scan_keys(fn)
+                data = self.gpg.scan_keys_file(fn)
                 self.assertEqual(0, data.returncode, 'Non-zero return code')
                 uids = set()
                 for d in data:

--- a/test_gnupg.py
+++ b/test_gnupg.py
@@ -707,7 +707,7 @@ class GPGTestCase(unittest.TestCase):
         logger.debug('testing other signature')
         self.assertTrue(('057CCF658C074FDA', 'Winston Smith (A test user) <winston@example.com>', '10x') in sigs)
 
-    def test_scan_keys_file(self):
+    def test_scan_keys(self):
         "Test that external key files can be scanned"
         # Don't use SkipTest for now, as not available for Python < 2.7
         if self.gpg.version < (2, 1):
@@ -718,7 +718,24 @@ class GPGTestCase(unittest.TestCase):
             ])
             for fn in ('test_pubring.gpg', 'test_secring.gpg'):
                 logger.debug('scanning keys in %s', fn)
-                data = self.gpg.scan_keys_file(fn)
+                data = self.gpg.scan_keys(fn)
+                self.assertEqual(0, data.returncode, 'Non-zero return code')
+                uids = set()
+                for d in data:
+                    uids.add(d['uids'][0])
+                self.assertEqual(uids, expected)
+
+    def test_scan_keys_mem(self):
+        "Test that external keys in memory can be scanned"
+        # Don't use SkipTest for now, as not available for Python < 2.7
+        if self.gpg.version < (2, 1):
+            expected = set([
+                'Gary Gross (A test user) <gary.gross@gamma.com>',
+                'Danny Davis (A test user) <danny.davis@delta.com>',
+            ])
+            for key in (KEYS_TO_IMPORT):
+                logger.debug('testing scan_keys')
+                data = self.gpg.scan_keys_mem(key)
                 self.assertEqual(0, data.returncode, 'Non-zero return code')
                 uids = set()
                 for d in data:
@@ -1498,7 +1515,7 @@ TEST_GROUPS = {
     set([
         'test_deletion', 'test_import_and_export', 'test_list_keys_after_generation', 'test_list_signatures',
         'test_key_generation_with_invalid_key_type', 'test_key_generation_with_escapes', 'test_key_generation_input',
-        'test_key_generation_with_colons', 'test_search_keys', 'test_scan_keys', 'test_key_trust', 'test_add_subkey',
+        'test_key_generation_with_colons', 'test_search_keys', 'test_scan_keys', 'test_scan_keys_mem', 'test_key_trust', 'test_add_subkey',
         'test_add_subkey_with_invalid_key_type', 'test_deletion_subkey', 'test_list_subkey_after_generation'
     ]),
     'import':


### PR DESCRIPTION
Changes:
- add new scan_keys_mem() that takes str or bytes
- add _decode_result(), broken out from _get_list_output()
- test for new scan_keys_mem()