### PR TITLE
Type hints for list_keys and scan_keys

### DIFF
--- a/gnupg.py
+++ b/gnupg.py
@@ -1816,7 +1816,7 @@ class GPG(object):
         self._collect_output(p, result, stdin=p.stdin)
         return self._decode_result(result)
 
-    def list_keys(self, secret=False, keys=None, sigs=False):
+    def list_keys(self, secret=False, keys=None, sigs=False) -> ListKeys:
         """
         List the keys currently in the keyring.
 
@@ -1847,7 +1847,7 @@ class GPG(object):
         p = self._open_subprocess(args)
         return self._get_list_output(p, 'list')
 
-    def scan_keys(self, filename):
+    def scan_keys(self, filename) -> ScanKeys:
         """
         List details of an ascii armored or binary key file without first importing it to the local keyring.
 


### PR DESCRIPTION
# Changes
I added return type hints for the `.list_keys()` and `scan_keys()` methods.

# Discussion
This is what I did with the `.list_keys()` method:
https://github.com/okurka12/python-gnupg/blob/c2070c683fcfcfcfc7ea547cf4e1371b504948e0/gnupg.py#L1819

It is somewhat inconsistent with what the docstring says:
https://github.com/okurka12/python-gnupg/blob/c2070c683fcfcfcfc7ea547cf4e1371b504948e0/gnupg.py#L1830-L1831

As far as I've understood, the `ListKeys` class is a descendant of the `list` class with some additional methods for internal use. To not expose these internal methods, we could maybe type hint the method to return type `list` instead.

Same goes for `.scan_keys()`

# Why I think this is necessary
I recently used this library to work with keys, and when I used `.list_keys()`, there was no type hint for my code editor to work with.

To make my life easier with the editor method/attribute suggestion, I looked what the method returns via `type()` and added that type hint in my code myself. Something like this:
```py
keylist: gnupg.ListKeys = gpg.list_keys()
```

This should not be necessary, as it slows down the user of the library.
