### PR TITLE
Drop redundant `wheel` from PEP 517 build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
     "setuptools >= 44",
-    "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
It's a mistake that ended up being copied all over GH. I've fixed it in `setuptools`' docs long ago. Old setuptools would auto-depend on it when needed. Modern setuptools vendor the wheel building command and don't use the external dep at all (it was moved in during last year's PyCon US Sprints).